### PR TITLE
calibration: use .iloc[0] so positional access works under pandas 2.x

### DIFF
--- a/sn_gamestate/calibration/baseline.py
+++ b/sn_gamestate/calibration/baseline.py
@@ -26,7 +26,7 @@ class BaselineCalibration(ImageLevelModule):
     def process(self, batch: Any, detections: pd.DataFrame, metadatas: pd.DataFrame):
         image = batch
         field = SoccerPitch()
-        predictions = metadatas["lines"][0]
+        predictions = metadatas["lines"].iloc[0]
         camera_predictions = dict()
 
         line_matches = []

--- a/sn_gamestate/calibration/nbjw_calib.py
+++ b/sn_gamestate/calibration/nbjw_calib.py
@@ -176,7 +176,7 @@ class NBJW_Calib(ImageLevelModule):
         return image
 
     def process(self, batch: Any, detections: pd.DataFrame, metadatas: pd.DataFrame):
-        predictions = metadatas["keypoints"][0]
+        predictions = metadatas["keypoints"].iloc[0]
 
         self.cam.update(predictions)
         h = self.cam.get_homography_from_ground_plane(use_ransac=50, inverse=True)

--- a/sn_gamestate/calibration/pnlcalib.py
+++ b/sn_gamestate/calibration/pnlcalib.py
@@ -180,8 +180,8 @@ class PnLCalib(ImageLevelModule):
         return image
 
     def process(self, batch: Any, detections: pd.DataFrame, metadatas: pd.DataFrame):
-        keypoints = metadatas["keypoints"][0]
-        lines = metadatas["lines_det"][0]
+        keypoints = metadatas["keypoints"].iloc[0]
+        lines = metadatas["lines_det"].iloc[0]
 
         self.cam.update(keypoints, lines)
         final_dict = self.cam.heuristic_voting_ground(refine_lines=self.refine_lines)


### PR DESCRIPTION
## Summary

Three calibration modules read the first row of their per-image metadata DataFrame with label-based lookup:

- `sn_gamestate/calibration/baseline.py` — `metadatas["lines"][0]`
- `sn_gamestate/calibration/nbjw_calib.py` — `metadatas["keypoints"][0]`
- `sn_gamestate/calibration/pnlcalib.py` — `metadatas["keypoints"][0]` and `metadatas["lines_det"][0]`

Under pandas 2.x these crash as soon as the DataFrame's index is not 0-based. The `ExternalVideo` wrapper (`dataset=video`) keeps the original `image_id` as the index, so the first frame immediately raises:

```
File ".../sn_gamestate/calibration/nbjw_calib.py", line 179, in process
    predictions = metadatas["keypoints"][0]
  File ".../pandas/core/series.py", line 1121, in __getitem__
    return self._get_value(key)
  File ".../pandas/core/series.py", line 1237, in _get_value
    loc = self.index.get_loc(label)
  File ".../pandas/core/indexes/range.py", line 417, in get_loc
    raise KeyError(key)
KeyError: 0
```

`.iloc[0]` selects the first positional row regardless of the index, which is what all three modules intend.

## Reproduction

Any pandas 2.x install, `dataset=video` (ExternalVideo wrapper or any path that preserves the caller's index), calibration module set to `baseline`, `nbjw_calib` or `pnlcalib`:

```bash
pip install "pandas>=2.0"
python -m tracklab.main -cn soccernet \
    dataset=video \
    modules.calibration=nbjw_calib \
    dataset.video_path=/path/to/clip.mp4
```

First frame raises `KeyError: 0` from the calibration module.

## Change

Four label-lookups → positional lookups:

```diff
 # sn_gamestate/calibration/baseline.py
-        predictions = metadatas["lines"][0]
+        predictions = metadatas["lines"].iloc[0]

 # sn_gamestate/calibration/nbjw_calib.py
-        predictions = metadatas["keypoints"][0]
+        predictions = metadatas["keypoints"].iloc[0]

 # sn_gamestate/calibration/pnlcalib.py
-        keypoints = metadatas["keypoints"][0]
-        lines = metadatas["lines_det"][0]
+        keypoints = metadatas["keypoints"].iloc[0]
+        lines = metadatas["lines_det"].iloc[0]
```

## Risk

None on datasets that do `reset_index(drop=True)` before the calibration module runs — then index 0 == position 0 and `.iloc[0]` returns the same row as `[0]` would. The change is strictly a bug fix: it makes the code work for the full range of DataFrame indexes, not just the 0-based case.

## Context

Encountered running `sn-gamestate` end-to-end on a Blackwell (sm_120) GPU with a fresh pandas 2.x install. Filed alongside a sibling PR to `TrackingLaboratory/tracklab` for a related Windows-path fix; both were needed to get a mixed-OS pipeline running.
